### PR TITLE
 Fixed: Cosmos.Logging.Args contained parameters that were not processed by the renderer. 

### DIFF
--- a/src/Cosmos.Logging.Extensions.EntityFrameworkCore/Cosmos.Logging.Extensions.EntityFrameworkCore.csproj
+++ b/src/Cosmos.Logging.Extensions.EntityFrameworkCore/Cosmos.Logging.Extensions.EntityFrameworkCore.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Alexinea.EntityFrameworkCore.LoggingExposure" Version="2.2.4" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
     </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.Extensions.Exceptions.MySqlConnector/Cosmos.Logging.Extensions.Exceptions.MySqlConnector.csproj
+++ b/src/Cosmos.Logging.Extensions.Exceptions.MySqlConnector/Cosmos.Logging.Extensions.Exceptions.MySqlConnector.csproj
@@ -13,6 +13,6 @@
         <ProjectReference Include="..\Cosmos.Logging.Extensions.Exceptions\Cosmos.Logging.Extensions.Exceptions.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="MySqlConnector" Version="0.61.0" />
+      <PackageReference Include="MySqlConnector" Version="0.62.0-beta4" />
     </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.Extensions.FreeSql/Cosmos.Logging.Extensions.FreeSql.csproj
+++ b/src/Cosmos.Logging.Extensions.FreeSql/Cosmos.Logging.Extensions.FreeSql.csproj
@@ -13,6 +13,6 @@
         <ProjectReference Include="..\Cosmos.Logging\Cosmos.Logging.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="FreeSql" Version="0.9.16" />
+      <PackageReference Include="FreeSql" Version="0.12.5" />
     </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.RunsOn.AspNet.WithAutofac/Cosmos.Logging.RunsOn.AspNet.WithAutofac.csproj
+++ b/src/Cosmos.Logging.RunsOn.AspNet.WithAutofac/Cosmos.Logging.RunsOn.AspNet.WithAutofac.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Alexinea.Autofac.Extensions.DependencyInjection" Version="4.2.0" />
-    <PackageReference Include="Autofac" Version="4.8.1" />
+    <PackageReference Include="Autofac" Version="4.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Logging.RunsOn.AspNet/Cosmos.Logging.RunsOn.AspNet.csproj
+++ b/src/Cosmos.Logging.RunsOn.AspNet/Cosmos.Logging.RunsOn.AspNet.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.6" />
+        <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/Cosmos.Logging.RunsOn.ZKWeb/Cosmos.Logging.RunsOn.ZKWeb.csproj
+++ b/src/Cosmos.Logging.RunsOn.ZKWeb/Cosmos.Logging.RunsOn.ZKWeb.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\Cosmos.Logging\Cosmos.Logging.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ZKWeb" Version="2.2.1" />
+    <PackageReference Include="ZKWeb" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.Sinks.NLog/Cosmos.Logging.Sinks.NLog.csproj
+++ b/src/Cosmos.Logging.Sinks.NLog/Cosmos.Logging.Sinks.NLog.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\Cosmos.Logging\Cosmos.Logging.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog" Version="4.6.8" />
   </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.Sinks.TencentCloudCls/Cosmos.Logging.Sinks.TencentCloudCls.csproj
+++ b/src/Cosmos.Logging.Sinks.TencentCloudCls/Cosmos.Logging.Sinks.TencentCloudCls.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Cosmos.Encryption" Version="0.1.1-alpha6-123080" />
-        <PackageReference Include="Google.Protobuf" Version="3.7.0" />
-        <PackageReference Include="ServiceStack.ProtoBuf" Version="5.5.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.11.0-rc2" />
+        <PackageReference Include="ServiceStack.ProtoBuf" Version="5.7.0" />
     </ItemGroup>
 </Project>

--- a/src/Cosmos.Logging.Sinks.TomatoLog/Cosmos.Logging.Sinks.TomatoLog.csproj
+++ b/src/Cosmos.Logging.Sinks.TomatoLog/Cosmos.Logging.Sinks.TomatoLog.csproj
@@ -38,8 +38,8 @@
 
     <ItemGroup>
         <PackageReference Include="Cosmos.Encryption" Version="0.1.1-alpha6-123080" />
-        <PackageReference Include="Google.Protobuf" Version="3.7.0" />
-        <PackageReference Include="ServiceStack.ProtoBuf" Version="5.5.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.11.0-rc2" />
+        <PackageReference Include="ServiceStack.ProtoBuf" Version="5.7.0" />
         <PackageReference Include="TomatoLog.Client" Version="1.2.0" />
         <PackageReference Include="TomatoLog.Client.Redis" Version="1.2.0" />
         <PackageReference Include="TomatoLog.Client.RabbitMQ" Version="1.2.0" />

--- a/src/Cosmos.Logging/Args.cs
+++ b/src/Cosmos.Logging/Args.cs
@@ -1,10 +1,18 @@
-﻿namespace Cosmos.Logging {
-    public class Args {
+﻿namespace Cosmos.Logging
+{
+    public class Args
+    {
         private object[] _args;
         public Args(params object[] args) => _args = args;
 
-        public static explicit operator object[](Args args) {
+        public static explicit operator object[](Args args)
+        {
             return args._args;
+        }
+
+        public override string ToString()
+        {
+            return Newtonsoft.Json.JsonConvert.SerializeObject(_args);
         }
     }
 }

--- a/src/Cosmos.Logging/Core/ArgsHelper.cs
+++ b/src/Cosmos.Logging/Core/ArgsHelper.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cosmos.Logging.Core
+{
+    internal static class ArgsHelper
+    {
+        public static object[] CleanUp(object[] messageTemplateParameters)
+        {
+            if (messageTemplateParameters == null)
+                return null;
+
+            var ret = new List<object>();
+            var lazy = new List<object>();
+
+            foreach (var parameter in messageTemplateParameters)
+            {
+                if (parameter is Args args)
+                {
+                    var realArgs = CleanUp((object[]) args);
+
+                    if (realArgs.Length == 0)
+                        continue;
+
+                    if (realArgs.Length == 1)
+                    {
+                        ret.Add(realArgs[0]);
+                    }
+                    else
+                    {
+                        ret.Add(realArgs[0]);
+                        
+                        for (var i = 1; i < realArgs.Length; i++)
+                            lazy.Add(realArgs[i]);
+                    }
+                }
+                else
+                {
+                    ret.Add(parameter);
+                }
+            }
+
+            return ret.Concat(lazy).ToArray();
+        }
+    }
+}

--- a/src/Cosmos.Logging/Cosmos.Logging.csproj
+++ b/src/Cosmos.Logging/Cosmos.Logging.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="AspectCore.Core" Version="1.3.0" />
     <PackageReference Include="AspectCore.Extensions.Reflection" Version="1.3.0" />
-    <PackageReference Include="Enums.NET" Version="2.3.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.6.0-rc1.19456.4" />
+    <PackageReference Include="Enums.NET" Version="3.0.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0-preview3.19551.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/src/Cosmos.Logging/LoggerBase.cs
+++ b/src/Cosmos.Logging/LoggerBase.cs
@@ -67,10 +67,11 @@ namespace Cosmos.Logging {
             LogEventContext context = null, params object[] messageTemplateParameters) {
             if (!IsEnabled(level)) return;
             if (string.IsNullOrWhiteSpace(messageTemplate)) return;
+            var cleanMessageTemplateParameters = ArgsHelper.CleanUp(messageTemplateParameters);
             if (IsManuallySendMode(sendMode)) {
-                ParseAndInsertLogEvenDescriptorManually(eventId ?? new LogEventId(), level, exception, messageTemplate, callerInfo, context, messageTemplateParameters);
+                ParseAndInsertLogEvenDescriptorManually(eventId ?? new LogEventId(), level, exception, messageTemplate, callerInfo, context, cleanMessageTemplateParameters);
             } else {
-                ParseAndInsertLogEventIntoQueueAutomatically(eventId ?? new LogEventId(), level, exception, messageTemplate, callerInfo, context, messageTemplateParameters);
+                ParseAndInsertLogEventIntoQueueAutomatically(eventId ?? new LogEventId(), level, exception, messageTemplate, callerInfo, context, cleanMessageTemplateParameters);
             }
         }
 

--- a/tests/Cosmos.Logging.MessageTemplateTokenTests/Program.cs
+++ b/tests/Cosmos.Logging.MessageTemplateTokenTests/Program.cs
@@ -8,10 +8,13 @@ using Cosmos.Logging.MessageTemplates;
 using Cosmos.Logging.Sinks.SampleLogSink;
 using Microsoft.Extensions.Configuration;
 
-namespace Cosmos.Loggings.MessageTemplateTokenTests {
-    class Program {
+namespace Cosmos.Loggings.MessageTemplateTokenTests
+{
+    class Program
+    {
 
-        static void Preheater(MessageTemplateCachePreheater preheater) {
+        static void Preheater(MessageTemplateCachePreheater preheater)
+        {
             preheater.Add("token test: {@Hello}, {0}, {@World}");
             preheater.Add("token test: {@Hello}, {0}, {@World}1");
             preheater.Add("token test: {@Hello:U}, {0:U}, {@World},{1}, {$ConsoleHelloWorld}, {$Hello}, {@Alewix}, {3}");
@@ -19,8 +22,10 @@ namespace Cosmos.Loggings.MessageTemplateTokenTests {
 
         static object SyncLock = new object();
 
-        static void Main(string[] args) {
-            try {
+        static void Main(string[] args)
+        {
+            try
+            {
                 var root = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("appsettings.json", true, true).Build();
 
@@ -138,17 +143,63 @@ namespace Cosmos.Loggings.MessageTemplateTokenTests {
 //                logger.LogInformation("position test{10:w}");
 //                logger.LogInformation("position test{10:w:} ");
 
-                logger.LogInformation("{$Date::yyyy年MM月dd日} token test: {@Hello:U}, {0:U}, {@World},{1}, {$ConsoleHelloWorld}, {$Hello}, {@Alewix}, {3}",
-                    new Args(new {Hello = "_hello_"}, "?world?"));
-                logger.LogInformation("token test: {@Hello}, {0}, {@World}？？？？？", new Args(new {Hello = "_hello_", World = "_world_"}, "?world?"));
+//                logger.LogInformation("{$Date::yyyy年MM月dd日} token test: {@Hello:U}, {0:U}, {@World},{1}, {$ConsoleHelloWorld}, {$Hello}, {@Alewix}, {3}",
+//                    new Args(new {Hello = "_hello_"}, "?world?"));
+                logger.LogInformation(@"
+{{多字段匿名对象测试1：基于 Cosmos.Logging.Args 的测试}}
+Hello: {@Hello},
+World: {@World},
+    0: {0},
+    1: {1},
+    2: {2},
+Hello: {@Hello},
+World: {@World}",
+                    new Args(new {Hello = "_hello_", World = "_world_"}, "?world?"), arg2: "_position_1_");
 
-                using (var scope = logger.BeginScope("123")) {
-                    logger.LogInformation("token test: {@Hello}, {0}, {@World}");
-                }
+                logger.LogInformation(@"
+{{多字段匿名对象测试2：基于普通匿名对象的测试}}
+Hello: {@Hello},
+World: {@World},
+    0: {0},
+    1: {1},
+    2: {2},
+Hello: {@Hello},
+World: {@World}",
+                    new {Hello = "_hello_"}, "?world?", new {World = "_world_"});
+
+                logger.LogInformation(@"
+{{多字段匿名对象测试3：基于匿名类包含 Cosmos.Logging.Args 的测试}}
+Hello: {@Hello},
+World: {@World},
+    0: {0},
+    1: {1},
+    2: {2},
+    3: {3},
+Hello: {@Hello},
+World: {@World}",
+                    new Args(new {Hello = "_hello_", _ = new Args(new {World = "_world_"})}, "?world?"), arg2: "_position_1_");
+
+                logger.LogInformation(@"
+{{多字段匿名对象测试4：基于嵌套了 Cosmos.Logging.Args 的测试}}
+Hello: {@Hello},
+World: {@World},
+    0: {0},
+    1: {1},
+    2: {2},
+    3: {3},
+    4: {4},
+Hello: {@Hello},
+World: {@World}",
+                    new Args(new {Hello = "_hello_", _ = new Args(new {__World = "_world_"})}, "?world?", new Args(new {World = "_world_"})), arg2: "_position_1_");
+
+//                using (var scope = logger.BeginScope("123")) {
+//                    logger.LogInformation("token test: {@Hello}, {0}, {@World}");
+//                }
 
                 Console.WriteLine("I'm live");
             }
-            catch (Exception e) {
+            catch (Exception e)
+            {
                 Console.WriteLine(e.Message);
                 Console.WriteLine(e.Source);
 

--- a/tests/Cosmos.Logging.SampleSinkTests/Program.cs
+++ b/tests/Cosmos.Logging.SampleSinkTests/Program.cs
@@ -14,6 +14,7 @@ namespace Cosmos.Logging.SampleSinkTests {
                 var logger = LOGGER.GetLogger<Program>(mode: LogEventSendMode.Manually);
 
                 logger.LogInformation("hello");
+                logger.LogInformation("hello {0},number={1}", new {A = "1"}, 2);
                 logger.LogError("world", ctx => ctx.SetTags("Alex").SetTags("Lewis"));
                 logger.LogError("Nice {@L}", ctx => ctx.SetParameter(new {L = "KK"}));
                 logger.SubmitLogger();


### PR DESCRIPTION
 Fixed: Cosmos.Logging.Args contained parameters that were not processed by the renderer. 

